### PR TITLE
Editorial review of part 1

### DIFF
--- a/docs/part1/00-objectives.md
+++ b/docs/part1/00-objectives.md
@@ -1,30 +1,39 @@
-# Part 1: End-to-end deployment of a sample web application on top of a secure VPC-topology
+# Part 1: End-to-end deployment of a sample web application on a secure VPC topology
 
-This section of the lab walks through the steps to provision a secure VPC-based topology aligned with the with Financial the **VSI on VPC landing zone** Deployable Architecture as show in the diagram below. 
+In part 1, you provision a secure VPC-based topology that is aligned with the **VSI on VPC landing zone** deployable architecture, as shown in the following diagram.
 
 ![](https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-landing-zone/main/reference-architectures/vsi-vsi.drawio.svg 'size=60%' )
 
-We will then manually customize the deployed infrastructure to:
-1. Expose one of the VSI in the management VPC to act as a "jump box" for operator access. This jump box is the entry point for operators to access the VSIs in the workload VPC.
-2. Deploy an Apache server in a VSI in the workload VPC.
-3. Expose the web pages served by the Apache service to the internet through a public load balancer.
 
+After you provision the VPC, you customize the deployed infrastructure in the following ways:
+- Expose one of the VSI in the management VPC to act as a "jump box" for operator access. This jump box is the entry point for operators to access the VSIs in the workload VPC.
+- Deploy an Apache server in a VSI in the workload VPC.
+- Expose the web pages that are served by the Apache server to the internet through a public load balancer.
 
 ## Lab Prerequisites :white_check_mark:
 
 ?> _TODO_ review
 
+Make sure that you meet the following prerequisites before you begin the lab.
 
-- An IBM Cloud Pay-As-You-Go or Subscription account.
-:information_source: **Note**:  Participants in the TechXchange classroom will be provided with credentials to access an IBM Cloud account for the duration of the lab.
-- An IBMId
-- API Key with the following permissions...
+- IBM Cloud
+    - An IBM Cloud Pay-Go or Subscription account
 
-A development machine with the following software:
-- [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
-- Text editor of your choice
-- Web browser
-- Tools to generate SSH key. Linux and Mac comes with ssh-keygen. [PuTTYgen](https://www.ssh.com/academy/ssh/putty/windows/puttygen) can be used on Windows. See [Generating an external SSH key](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys&interface=ui#generating-ssh-keys)
-- Optional: [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
+        :information_source: **Note**:  Participants in the TechXchange classroom will be provided with credentials to access an IBM Cloud account during the lab.
+    - An IBMid
+    - API key with the following permissions
 
-:information_source: **Note**:  Participants in the TechXchange classroom will be provided with a development VM with pre-installed software.
+        ?> _TODO_ review
+
+- A development computer with the following software.
+    - [Terraform](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli)
+    - Text editor of your choice
+    - Web browser
+    - Tools to generate SSH key
+        - Linux and Mac come with ssh-keygen.
+        - Windows users can use [PuTTYgen](https://www.ssh.com/academy/ssh/putty/windows/puttygen)
+
+        For more information, see [Generating an external SSH key](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys&interface=ui#generating-ssh-keys).
+    - Optional: [IBM Cloud CLI](https://cloud.ibm.com/docs/cli?topic=cli-getting-started)
+
+:information_source: **Note**:  Participants in the TechXchange classroom will be provided with a development VM with the prerequisite software installed.

--- a/docs/part1/10-project.md
+++ b/docs/part1/10-project.md
@@ -1,53 +1,75 @@
-# Deploying Landing Zone VSI pattern through IBM Cloud Project
+# Deploying the Landing Zone VSI pattern through IBM Cloud projects
 
-1. On your machine, create an SSH key pair via the command:
-   ```
-   ssh-keygen -t rsa -b 4096 -N '' -f ./lab-key
-   ```
-   This command generates two files in the current directory: `lab-key` (the private key) and `lab-key.pub` (the public key).
-   Verify that the keys have been created in the current directory.
-   ```
-   ls lab-key*
-   ```
-   This should return:
-   ```
-   lab-key  lab-key.pub
-   ```
-2. Access the [VSI on VPC landing zone Deployable Architecture](https://cloud.ibm.com/catalog/architecture/deploy-arch-ibm-slz-vsi-ef663980-4c71-4fac-af4f-4a510a9bcf68-global?catalog_query=aHR0cHM6Ly9jbG91ZC5pYm0uY29tL2NhdGFsb2cjcmVmZXJlbmNlX2FyY2hpdGVjdHVyZQ%3D%3D)
-3. On the Overview page, make sure the following is selected:\
-   a. Product version: **Select the latest** (4.4.7 at the time of writting)
+1. On your computer, create an SSH key pair by issuing the following command:
 
-   b. Variation: Standard
-   ![Overview page](../images/part-1/10-overview-page.png)
-4. Click **Review deployment options** on the bottom right
-5. Click **Add to project**
-6. Under _Create New_, input a name that you wish to provide to the project. For example "\<your initials\> Landing Zone Lab"
-7. Click **Add** on the bottom right
-8. Under _Configure -> Security_ section, set the following:\
-   a. Authentication: untoggle _Use a secret_ and paste your IBM Cloud API key input the box
+    ```sh
+    ssh-keygen -t rsa -b 4096 -N '' -f ./lab-key
+    ```
 
-9. Under _Configure->Required_ section, set the following:\
-   a. `ssh_public_key`: The value of lab-key.pub that was generated from step 1\
-   b. `region`: Select a region that you wish to deploy in\
-   c. `prefix`: your initials
-   ![Configuration](../images/part-1/10-configuration.png)
+    This command generates two files in the current directory: `lab-key` (the private key) and `lab-key.pub` (the public key.
 
-10. Under _Configure-> Optional_, set the following:\
-    a. `add_atracker_route`: false
-11. Click **Save**
-12. Click **Validate**
-13. The project will go through different steps in validation. When it completes, the validation is marked as successful. In the _Approval pending_ section, add a comment and click **Approve** to start provisioning.
+    List the keys exist in the current directory with the following command:
 
-![Validation](../images/part-1/10-validation.png)
+    ```sh
+    ls lab-key*
+    ```
 
-14. Click **Deploy**
+    If the SSH key pair succeeded, the output lists them:
 
+    ```sh
+    lab-key  lab-key.pub
+    ```
 
-:information_source: **Note**: The deploy will take approximately 15 minutes to complete. Some suggestions during this time:
-- You may following the execution logs. Of interest:
-   ![Deployment](../images/part-1/10-deployment.png)
-   - The terraform plan steps shows the list of resources that are going to be created.
-   - The terraform apply steps shows the resources that are being created.
-   - You may also navigate to the [VPC section](https://cloud.ibm.com/vpc-ext/vpcLayout) and the [resource list](https://cloud.ibm.com/resources) in your account to see the resources starting to spawn up as you refresh the screen during the execution.
-- Explore in more details some of the materials in the [introduction section](README)
-- Coffee ☕
+1. Add the deployable architecture to a project:
+
+    1. Access the [VSI on VPC landing zone Deployable Architecture](https://cloud.ibm.com/catalog/architecture/deploy-arch-ibm-slz-vsi-ef663980-4c71-4fac-af4f-4a510a9bcf68-global?catalog_query=aHR0cHM6Ly9jbG91ZC5pYm0uY29tL2NhdGFsb2cjcmVmZXJlbmNlX2FyY2hpdGVjdHVyZQ%3D%3D) in IBM Cloud.
+    1. On the VSI on VPC landing zone details page, make sure that the following settings are selected:
+        a. Product version: **Select the latest** (`4.4.7`` at the time of writing).
+        b. Variation: `Standard`
+
+        ![Details page](../images/part-1/10-overview-page.png)
+
+    1. Click **Review deployment options** on the lower right.
+    1. Click **Add to project**.
+    1. In **Create New**, enter a name for the project. For example, "\<your initials\> Landing Zone Lab". You can leave the other information as is.
+    1. Click **Add** on the lower right.
+
+1. Configure the project
+    1. In the **Configure** > **Security** section, specify the following information:
+      a. Authentication: Clear **Use a secret** and paste in your IBM Cloud API key.
+
+    1. In the **Configure** > **Required** section, specify the following settings:
+        a. `ssh_public_key`: The value of the `lab-key.pub` file that you generated in step 1.
+        b. `region`: The region that you want to deploy in.
+        c. `prefix`: Your initials.
+
+        ![Configuration](../images/part-1/10-configuration.png)
+
+    1. In the **Configure** > **Optional**, set the following options:
+        a. `add_atracker_route`: `false`.
+    1. Click **Save**.
+
+1. Validate and deploy the deployable architecture:
+    1. Click **Validate**.
+
+    The project runs through several validation steps. When it finishes, the validation is marked as successful. In the **Approval pending** section, add a comment and click **Approve** to start provisioning.
+
+    ![Validation](../images/part-1/10-validation.png)
+
+    1. Click **Deploy**
+
+        :information_source: **Tip**: Deployment takes approximately 15 minutes to complete.
+
+1. While you wait for the deployment to finish, consider doing these things:
+
+    - Look at the deployment logs:
+        - The Terraform plan steps show the list of resources that are going to be created.
+        - The Terraform apply steps shows the resources that are being created.
+
+        Example:
+
+      ![Deployment](../images/part-1/10-deployment.png)
+
+    - Go to the [VPC section](https://cloud.ibm.com/vpc-ext/vpcLayout) and the [resource list](https://cloud.ibm.com/resources) in your IBM Cloud account. Refresh the screen to see the resources that are created during deployment.
+    - Explore some of the materials in the [introduction](README) to this lab.
+    - Have a coffee ☕

--- a/docs/part1/20-operator-access.md
+++ b/docs/part1/20-operator-access.md
@@ -1,40 +1,53 @@
 # Providing operator access to the VPC landing zone
 
-## Introduction
+## Overview of operator access
 
-By default, network access to the VPC landing zone topology is locked down for security compliance reasons. In this section, you will open up the necessary access for an operator to access the VPC environment, including deploying application on the VSIs located in the workload VPC.
+By default, network access to the VPC landing zone topology is locked down for security compliance reasons. In this part of the lab, you open the necessary access for an operator to access the VPC environment, including deploying application on the VSIs located in the workload VPC.
 
-Operator access is provided through the _Management VPC_. There are multiple ways to give operator access to the VPC landing zone, with varying level of security, compliance, and ease of enablement:
+You give operator access through the _Management VPC_. You have several options to give operator access, with varying level of security, compliance, and ease of enablement.
 
 - Exposing a VSI in the management VPC as a ‘jump-box’ by assigning a public floating IP
 - Deploying a client-to-site VPN solution in the management VPC
 - Deploying a site-to-site VPN solution in the management VPC
 - Deploying a certified bastion solution, such as Gravitational Teleport in the management VPC.
 
-This part of the lab shows how to expose one of the VSI in the management VPC as a 'jump-box', as this is one of the simplest way to proceed, albeit not being strongly secure. The [Going Further](./part1/50-going-further) section below provides links to some of the other ways to provide operator access.
+In this lab, you expose one of the VSIs in the management VPC as a 'jump-box'. This method is one of the simplest ways to proceed, although it is not overly secure. The [Going further](./part1/50-going-further) section later in the lab provides links to some of the other ways that you can provide operator access.
 
 ## Steps
 
-Perform the following actions to enable public ssh access to one of the VSI in the management VPC. This VSI will be the unique operator entry point ('jump-box') to the landing zone VPC topology.
+Complete the following steps to enable public SSH access to one of the VSI in the management VPC. This VSI is the unique operator entry point ('jump-box') to the landing zone VPC topology.
 
-1. Access the [Virtual server instances for VPC list](https://cloud.ibm.com/vpc-ext/compute/vs)
-2. Verify that the region is set to the region you provisioned your resources and click the VSI labeled _&lt;initials&gt;-management-server-1_
-3. Add a Floating IP address by clicking the pencil icon in the Network Interface section and reserve a new floating IP
-   ![Pencil icon](../images/part-1/20-network-int-pencil.png)
+1. Access the [Virtual server instances for VPC list](https://cloud.ibm.com/vpc-ext/compute/vs).
+2. Verify that the region is set to the region you provisioned your resources and click the VSI labeled `<your_initials>-management-server-1`.
+3. Add a floating IP address by clicking the pencil icon in the Network Interface section. Reserve a new floating IP address.
 
-![Floating IP](../images/part-1/20-floating-ip.png)
+    ![Pencil icon](../images/part-1/20-network-int-pencil.png)
 
-4. Take note of the public Floating IP. This IP will be used in a subsequent step.
-5. In the [Security Groups for VPC](https://cloud.ibm.com/vpc-ext/network/securityGroups), click the one labelled _&lt;initials&gt;-management_
-6. Go to the Rules section and allow port 22 for inbound by clicking **Create** in the _Inbound rules_ section (Note: Security groups are stateful so you don’t need to add a corresponding outbound rule)
+    :exclamation: **Important**: Take note of the public floating IP address. You need it later.
 
-![Allow SSH in Security group](../images/part-1/20-ssh-sg.png)
+    ![Floating IP address](../images/part-1/20-floating-ip.png)
 
-7. Click **Create**
-8. In the [Access control lists for VPC](https://cloud.ibm.com/vpc-ext/network/acl), click the one labeled _&lt;initials&gt;-management-acl_
+5. In the [Security Groups for VPC](https://cloud.ibm.com/vpc-ext/network/securityGroups), click the one labeled `<your_initials>-management`.
+6. Go to the Rules section and allow port 22 for inbound by clicking **Create** in the _Inbound rules_ section.
+
+    :information_source: **Tip**: Security groups are stateful so you don’t need to add a corresponding outbound rule.
+
+    ![Allow SSH in Security group](../images/part-1/20-ssh-sg.png)
+
+7. Click **Create**.
+8. In the [Access control lists for VPC](https://cloud.ibm.com/vpc-ext/network/acl), click the one labeled `<your_initials>-management-acl`.
 9. Create the following ACL inbound rule:
-   ![SSH ACL Inbound rule](../images/part-1/20-ssh-acl-inbound.png)
-10. Create the folloiwng ACL outbound rule:
-   ![SSH ACL Outbound rule](../images/part-1/20-ssh-acl-outbound.png)
-11. You will now be able to access the 'jump-box' through the public Floating IP address that you provisioned in a prior step. On your workstation, issue the following command from a terminal\
-    `ssh -i ./lab-key root@<Floating IP of Virtual server instance>`
+
+    ![SSH ACL Inbound rule](../images/part-1/20-ssh-acl-inbound.png)
+
+10. Create the following ACL outbound rule:
+
+    ![SSH ACL Outbound rule](../images/part-1/20-ssh-acl-outbound.png)
+
+11. You can now access the 'jump-box' through the public floating IP address that you provisioned earlier. On your computer, issue the following command from the terminal or command window:
+
+    ```sh
+    ssh -i ./lab-key root@<Floating IP of Virtual server instance>
+    ```
+
+    Replace \<Floating IP of Virtual server instance> with the address that you reserved earlier.

--- a/docs/part1/30-apache-server.md
+++ b/docs/part1/30-apache-server.md
@@ -1,31 +1,61 @@
-# Deploying an Apache Server in the Workload VPC
+# Deploying an Apache server in the Workload VPC
 
-In this section, you will install the Apache server on a workload VSI.
+In this part of the lab, you install an Apache server on a workload VSI.
 
-1. By default, the workload VSI (Virtual Server Instances) are locked down from the management VPC. You will need to allow access through the Access control list. In the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl), click the ACL labeled _&lt;initials&gt;-workload-acl_.
-   1. Create an ACL inbound rule to allow ssh access from the Management VPC
-      ![Workload SSH ACL Inbound rule](../images/part-1/30-workload-ssh-acl-inbound.png)
-   2. Create an ACL outbound rule to allow ssh access from the Management VPC
-      ![Workload SSH ACL Outbound rule](../images/part-1/30-workload-ssh-acl-outbound.png)
-2. In the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl), click the ACL labeled _&lt;initial&gt;-management-acl_.
-   1. Create an ACL inbound rule to allow ssh access from the Workload VPC
+By default, the workload VSI (Virtual Server Instance) is locked down from the management VPC. You need to allow access through the access control list.
+
+1. In the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl), click the ACL labeled `<your_initials>-workload-acl`.
+    1. Create an ACL inbound rule to allow ssh access from the Management VPC.
+
+        ![Workload SSH ACL Inbound rule](../images/part-1/30-workload-ssh-acl-inbound.png)
+
+    1. Create an ACL outbound rule to allow ssh access from the Management VPC.
+
+        ![Workload SSH ACL Outbound rule](../images/part-1/30-workload-ssh-acl-outbound.png)
+
+1. In the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl), click the ACL labeled `<your_initials>-management-acl`.
+    1. Create an ACL inbound rule to allow ssh access from the Workload VPC.
+
       ![Management SSH ACL Inbound rule](../images/part-1/30-mgmt-ssh-acl-inbound.png)
-   2. Create an ACL outbound rule to allow ssh access from the Workload VPC
+
+    1. Create an ACL outbound rule to allow ssh access from the Workload VPC.
+
       ![Management SSH ACL Outbound rule](../images/part-1/30-mgmt-ssh-acl-outbound.png)
-3. Access the workload VSI by doing the following:
-   1. Navigate to [Virtual server instances for VPC](https://cloud.ibm.com/vpc-ext/compute/vs). Take note of the private IP ("Reserved IP") for the VSI labeled *initials-workload-server-1* (10.40.10.4 in this example).
-   ![private IP](../images/part-1/30-private-ip.png)
-   2. From your machine, copy the private key labeled *lab_key* to the bastion host
-      `scp -i lab-key lab-key root@<Floating IP address of bastion host>:/root`
-   3. SSH to the bastion host
-      `ssh -i ./lab-key root@<Floating IP of Virtual server instance>`
-   4. Change permissions of the private key
-      `chmod 600 lab-key`
-   5. SSH to the workload VSI
-      `ssh -i ./lab-key root@<Private IP address of the workload VSI>`
-4. Install the Apache web server by issuing the following commands:
-   ```shell
-   apt-get update
-   apt-get install apache2 --yes
+
+1. Access the workload VSI by completing the following steps:
+    1. Go to [Virtual server instances for VPC](https://cloud.ibm.com/vpc-ext/compute/vs). Take note of the private IP("Reserved IP") for the VSI labeled `<your_initials-workload-server-1` (`10.40.10.4` in this example). You need it later.
+
+        ![Private IP](../images/part-1/30-private-ip.png)
+
+    1. From your computer, copy the private key that is labeled `lab_key`` to the Bastion host.
+
+        ```sh
+        scp -i lab-key lab-key root@<Floating IP address of bastion host>:/root
+        ```
+
+   1. SSH to the bastion host
+
+      ```sh
+      ssh -i ./lab-key root@<Floating IP of Virtual server instance>
+      ```
+
+   1. Change permissions of the private key
+
+      ```sh
+      chmod 600 lab-key
+      ```
+
+   1. SSH to the workload VSI
+
+      ```sh
+      ssh -i ./lab-key root@<Private IP address of the workload VSI>
+      ```
+
+1. Install the Apache web server by issuing the following commands:
+
+    ```sh
+    apt-get update
+    apt-get install apache2 --yes
    ```
-5. (Optional) You may repeat the steps 3 and 4 for the workload VSIs *<initials>-workload-server-2* and *<initials>-workload-server-3*
+
+1. (Optional) You can repeat steps 3 and 4 for the workload VSIs `<your_initials>-workload-server-2` and `<your_initials>-workload-server-3`

--- a/docs/part1/40-expose-web-app.md
+++ b/docs/part1/40-expose-web-app.md
@@ -1,37 +1,48 @@
 # Exposing the web application to the internet
 
-In this section, we will expose the web pages to the internet through a VPC load balancer so anyone can access them.
+In this part of the lab, you expose the web pages to the internet through a VPC load balancer so that anyone can access them.
 
-1.  Create a public load balancer to expose the web application. Access the [Load balancers for VPC](https://cloud.ibm.com/vpc-ext/network/loadBalancers) page and click **Create**.
-2.  Set the following for the load balancer:
+1.  Create a public load balancer to expose the web application.
+    1. Access the [Load balancers for VPC](https://cloud.ibm.com/vpc-ext/network/loadBalancers) page.
+    1. Click **Create**.
+1.  Specify the following settings for the load balancer:
     - Load balancer type: Application Load Balancer (ALB)
     - Location: Location that you provision your VPC resources
     - Details:
-      - Name: &lt;initials&gt;-web-lb
-      - Virtual private cloud: &lt;initials&gt;-workload-vpc
-      - Type: Public
-      - DNS type: Public
-      - Subnets: &lt;initials&gt;-workload-vsi-zone-1
+        - Name: `<your_initials>-web-lb`
+        - Virtual private cloud: `<your_initials>-workload-vpc`
+        - Type: `Public`
+        - DNS type: `Public`
+        - Subnets: `<your_initials>-workload-vsi-zone-1`
     - Backend pool:
-      - Name: &lt;initials&gt;-backend-pool
-      - Pool protocol: HTTP
-      - Health Port: 80
-    - Click **Attach server +** in the Back-end pools section and add the VSI that is in the subnet &lt;initials&gt;-workload-vsi-zone-1 with a server port of 80
-    - Create a front-end listener by clicking **Create listener** and set the following:
-      - Listener port: 80
-    - Under the _Security Group_ section, unselect all except the one labeled &lt;initials&gt;-workload
-    - Click **Create load balancer**
-3.  Allow access to the load balancer by adding the following inbound rule to the [security group](https://cloud.ibm.com/vpc-ext/network/securityGroups) called &lt;initials&gt;-workload that the load balancer is attached.
-    ![Inbound security group rule](../images/part-1/40-sg.png)
-4.  Allow internet access to the load balancer by adding the following rules to the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl) for the ACL &lt;initials&gt;-workload-acl.
+        - Name: `<your_initials>-backend-pool`
+        - Pool protocol: `HTTP`
+        - Health Port: `80`
+    - Click **Attach server +** in the Back-end pools section and add the VSI that is in the subnet `<your_initials>-workload-vsi-zone-1` with a server port of `80`.
+    - Create a front-end listener by clicking **Create listener** and set the Listener port to `80`.
+    - Under the _Security Group_ section, clear all settings except the one labeled `<your_initials>-workload`.
+    - Click **Create load balancer**.
+1.  Allow access to the load balancer by adding the following inbound rule to the [security group](https://cloud.ibm.com/vpc-ext/network/securityGroups) called `<your_initials>-workload` that the load balancer is attached.
+
+      ![Inbound security group rule](../images/part-1/40-sg.png)
+
+1. Allow internet access to the load balancer by adding the following rules to the [Access control list](https://cloud.ibm.com/vpc-ext/network/acl) for the ACL `<your_initials>-workload-acl`.
     - Create an inbound rule
-      ![ACL inbound rule](../images/part-1/40-acl-inbound.png)
+
+        ![ACL inbound rule](../images/part-1/40-acl-inbound.png)
+
     - Create an outbound rule
-      ![ACL outbound rule](../images/part-1/40-acl-outbound.png)
-5.  It can take several minutes for your load balancer to provision. Check and wait until the status is set to Active in [Load balancers for VPC](https://cloud.ibm.com/vpc-ext/network/loadBalancers). You may need click the refresh button in the page periodically.
-6.  You web application is exposed:
-    - Retrieve the FQDN of your Load balancer
-      - [Access the Load Balancer list](https://cloud.ibm.com/vpc-ext/network/loadBalancers) and click your provisioned load balancer
-      - Copy the value under _Hostname_
-    - On your machine, open up a web browser pointing to `http://<Hostname of your load balancer>` . You may also test connectivity by issuing the following command:
-      `curl http://<Hostname of your load balancer>`
+
+        ![ACL outbound rule](../images/part-1/40-acl-outbound.png)
+
+    :information_source: **Tip**: It can take several minutes for your load balancer to provision. Wait until the status is set to `Active` in [Load balancers for VPC](https://cloud.ibm.com/vpc-ext/network/loadBalancers). You might need to refresh the page periodically.
+
+1. Complete these steps after your web application is exposed:
+    1. Retrieve the FQDN of your load balancer:
+        1. [Access the Load Balancer list](https://cloud.ibm.com/vpc-ext/network/loadBalancers) and click your provisioned load balancer.
+        1. Copy the value under `Hostname`.
+    1. On your computer, open a web browser and point it to `http://<hostname of your load balancer>`. You can also test connectivity by issuing the following curl command:
+
+        ```sh
+        curl http://<Hostname of your load balancer>
+        ```

--- a/docs/part1/50-going-further.md
+++ b/docs/part1/50-going-further.md
@@ -1,25 +1,29 @@
-# Going further.....
+# Going further
 
-In the interest of simplicity, as a gentle introduction, this lab gives operator access through a VSI jumpbox in management and expose directly the application through public load-balancer attached to the worker VPC.
+To keep the lab simple, you give operator access through a VSI jump-box in the management VPC. Then you expose the web application directly through a public load balancer that is attached to the worker VPC.
 
-Whilst this approach provides a reasonable level of security and checks a number of compliance controls, and may be sufficient for a number of industries and enterprises, the sections below describe a number of aspects to consider to enhance secure and compliance posture, including links to relevant documentation and automation.
+These approaches provide a reasonable level of security, satisfy a number of compliance controls, and might be sufficient for a number of industries and enterprises. If you want more security and need to comply with different controls, consider the following information to set a more secure and compliant posture.
 
-## Operator access
+## Other ways to provide operator access
 
-There are a more secure options for providing network connectivity to the management VPCs:
+Some secure options to consider for providing network connectivity to the management VPCs.
 
-- A Client-To-Site VPN, whereby the operator has a VPN client on their environment that connect to a VPN server running the management VPC. IBM Cloud provides [a client-to-site VPN solution](https://cloud.ibm.com/docs/vpc?topic=vpc-vpn-client-to-site-overview) out-of-the-box that can be leveraged for this purpose. An [example of automation deploying a client-to-site gateway in a landing-zone management VPC](https://github.com/terraform-ibm-modules/terraform-ibm-client-to-site-vpn/tree/main/extensions/landing-zone).
-  ![client-to-site vpn](../images/part-1/50-c2s.png)
-- A [site-to-site VPN](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn), to connect the management VPC to another private network. The landing-zone Deployable Architecture pre-creates a site-to-site gateway for this purpose.
-- Direct Link – extends an organization data center network. See [here](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-management) as a starting point for further details.
+- A Client-To-Site VPN, in which the operator has a VPN client on the environment that connects to a VPN server that is running the management VPC. IBM Cloud provides a default [client-to-site VPN solution](https://cloud.ibm.com/docs/vpc?topic=vpc-vpn-client-to-site-overview) that can be used for this purpose. For an example of automation to deploy a client-to-site gateway in a landing-zone management VPC, see [Client-To-Site VPN add-on for landing zone](https://github.com/terraform-ibm-modules/terraform-ibm-client-to-site-vpn/tree/main/extensions/landing-zone).
 
-From a compliance perspective, it is recommended to record all interactive operator actions. For doing so, a bastion solution is required. Operator connect through the bastion, which record all interactive session action for auditing purposes. The IBM cloud Framework for Financial Services has got more [details](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-bastion), and well as a tutorial to set up a bastion solution leveraging the 3rd party solution Teleport [here](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-bastion-tutorial-teleport).
+    ![Client-to-site VPN](../images/part-1/50-c2s.png)
+- A [site-to-site VPN](https://cloud.ibm.com/docs/vpc?topic=vpc-using-vpn) to connect the management VPC to another private network. The landing zone deployable architecture creates a site-to-site gateway for this purpose.
+- Direct LInk, which extends an organization data center network. For a starting point with more details, see [Connecting application provider to the management VPC](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-management).
 
-## Exposing the web application to the internet
+From a compliance perspective, record all interactive operator actions with a bastion solution. Operators connect through the bastion, which records all interactive session actions for auditing. For more information, see [Running operator actions through a bastion host
+](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-bastion) in the IBM cloud Framework for Financial Services docs. For a tutorial that uses the 3rd-party solution Teleport, see [Setting up a bastion host that uses Teleport](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-bastion-tutorial-teleport).
 
-In the lab, the workload is exposed through a public VPC load balancer attached to the workload VPC. There are a few additions that can be made to make the solution more secure:
-1. Introduce a web application firewall in the flow. This can be done in two ways:
-  - As-a-service - typically done through adding a global load balancer, such as IBM Cloud CIS or Akamai in front of the VPC load balancer, and adding a network ACL on the VPC load balancer to accept inbound traffic only from the global load balancer set of known IPs  
-  - Hosted – this can be achieved with 3rd party solution such as BigIP F5. This solution is deployed and hosted on machines that you run – for instance in VSIs in the landing-zone VPC topology. See [here](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-waf-tutorial) for a tutorial.
+## Other ways to expose the web application to the internet
 
-2. Create the public VPC load balancer in a separate ‘edge’ VPC. Route the traffic from the ‘edge’ VPC to the application running on the ‘workload’ VPC through a private load balancer (routable only from within the VPC topology). This approach ensures that there are no direct public network flows to the workload VPC. See this [page](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-workload#consumer-provider-public-internet) for more details.
+In the lab, the workload is exposed through a public VPC load balancer that is attached to the workload VPC. With the following additions, you can make the solution more secure.
+
+Introduce a web application firewall in the flow in one of two ways:
+
+- As-a-service: Typically, you add a global load balancer, such as IBM Cloud CIS or Akamai, in front of the VPC load balancer. Then, you add a network ACL on the VPC load balancer to accept inbound traffic only from the global load balancer set of known IP addresses.
+- Hosted: You can host the application with a 3rd-party solution, such as BigIP F5. This solution is deployed and hosted on servers that you run, for example in VSIs in the landing-zone VPC topology. For a tutorial, see [Setting up a web application firewall with F5 BIG-IP](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-waf-tutorial).
+
+Create the public VPC load balancer in a separate edge VPC. Route the traffic from the edge VPC to the application that is running on the workload VPC through a private load balancer (which is routable only from within the VPC topology). This approach ensures that no direct public network flows to the workload VPC. For more information, see [Connecting from public internet](https://cloud.ibm.com/docs/framework-financial-services?topic=framework-financial-services-vpc-architecture-connectivity-workload#consumer-provider-public-internet) in "Consumer connectivity to workload VPC".


### PR DESCRIPTION
review Part 1 for IBM style, grammar, terminology, and for consistency.

- where I revised the steps substantially, I converted the ordered lists prefixes to `1.` instead of sequential for easier revision later. Sorry that this creates a bigger diff than there really is to the content.
- add the `sh` highlighting and moved most commands to their own line for easy scanning.
- changed `&lt;` to `<` and changed variable to `your_initials` where I noticed. Also put that string into `<pre>` with backticks.

I checked the output locally, but make sure everything looks good as published.

Signed-off-by: Allen Dean <allen.dean@us.ibm.com>
